### PR TITLE
Modify markdown in setup for hyperlinks

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -1,8 +1,8 @@
 ---
 title: Setup
 ---
-1. Install (pytest)[https://docs.pytest.org/en/7.3.x/contents.html]
-2. Install (Coverage.py)[https://coverage.readthedocs.io/en/7.2.7/index.html]
+1. Install [pytest](https://docs.pytest.org/en/7.3.x/contents.html)
+2. Install [Coverage.py](https://coverage.readthedocs.io/en/7.2.7/index.html)
 
 
 {% include links.md %}


### PR DESCRIPTION
Was looking over the testing lesson and noticed the markdown for hyperlinks syntax might be backwards:
![image](https://github.com/INTERSECT-training/testing-lesson/assets/17032543/e23b283a-6dfe-4494-94fa-12087b164b6a)

The changes I propose turn "pytest" and "Coverage.py" into hyperlinks themselves w/o displaying the URLs.
Example of what it will look like now:
> 1. Install [pytest](https://docs.pytest.org/en/7.3.x/contents.html)

Hope this helps and thanks for putting this lesson together!